### PR TITLE
update 0.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - pip
     - cython >=0.28.5
-    - numpy >=1.13.3
+    - numpy
     - wheel
     - setuptools
   run:
@@ -29,7 +29,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - scipy >=0.19.1
     - joblib
-    - scikit-learn >=0.23.0
+    - scikit-learn >=0.24.0
 
 test:
   requires:
@@ -50,7 +50,6 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: scikit-learn contrib estimators
-
   description: |
     scikit-learn-extra is a Python module for machine learning that extends
     scikit-learn. It includes algorithms that are useful but do not satisfy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<38]
 requirements:
   build:
     - {{ compiler('c') }}
@@ -21,19 +21,20 @@ requirements:
     - python
     - pip
     - cython >=0.28.5
-    - numpy
+    - numpy >=1.13.3
     - wheel
     - setuptools
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - scipy
+    - scipy >=0.19.1
     - joblib
     - scikit-learn >=0.23.0
 
 test:
   requires:
     - pytest >=3.3.0
+    - pip
   imports:
     - sklearn_extra
   commands:
@@ -42,7 +43,7 @@ test:
     - export OPENBLAS_NUM_THREADS=1       # [not win]
     - export OMP_NUM_THREADS=1            # [not win]
     - pytest --verbose --pyargs sklearn_extra -k "not test_all_estimators"
-
+    - pip check
 about:
   home: https://github.com/scikit-learn-contrib/scikit-learn-extra
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn-extra" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b1bb5fedde47920eb4b3fa0a0c18f80cc7359d9d0496720178788c6153b8019
+  sha256: 7912d43384470d77609e53819d0291967f21010e5c3a3847f9026fc02f9c7893
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,6 +22,8 @@ requirements:
     - pip
     - cython >=0.28.5
     - numpy
+    - wheel
+    - setuptools
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - scipy
+    - scipy >=0.19.1
     - joblib
     - scikit-learn >=0.24.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - python
     - pip
     - cython >=0.28.5
-    - numpy
+    - numpy >=1.13.3
     - wheel
     - setuptools
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - scipy >=0.19.1
+    - scipy
     - joblib
     - scikit-learn >=0.24.0
 


### PR DESCRIPTION
## Scikit-learn-extra 0.3.0 Update 
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2059)
[Upstream](https://github.com/scikit-learn-contrib/scikit-learn-extra)
[Dependencies ](https://github.com/scikit-learn-contrib/scikit-learn-extra/blob/main/setup.py)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added `abs.yaml` to upload to Snowflake channel